### PR TITLE
Atualizar envio de pedido via webhook

### DIFF
--- a/api/enviar-pedido.js
+++ b/api/enviar-pedido.js
@@ -8,7 +8,9 @@ export default async function handler(req, res) {
   try {
     const pedido = req.body;
 
-    const url = "https://script.google.com/macros/s/AKfycbxCyDQIfz7-x-YP2paxUgKEF41Txa25PKYvbqE-DwenDqMELm7mCoe5Jd51iDk1LiDu/exec";
+    // Webhook para registrar o pedido
+    const url =
+      "http://145.223.31.139:5678/webhook/bd2cb2de-d81e-429a-8527-3dda5cf315d8";
 
     const response = await fetch(url, {
       method: "POST",

--- a/src/pages/Landing.js
+++ b/src/pages/Landing.js
@@ -94,8 +94,52 @@ export default function Landing() {
 
   const handleSubmit = (e) => {
     e.preventDefault();
-    console.log("Pedido enviado", { cart, ...form });
-    alert("Pedido enviado! Consulte o console para ver os dados.");
+
+    const id = Math.random().toString(36).substr(2, 9).toUpperCase();
+    const data = new Date().toISOString().split("T")[0];
+
+    const endereco =
+      form.recebimento === "entrega"
+        ? `${form.rua}, ${form.numero}${form.complemento ? ' - ' + form.complemento : ''}, ${form.bairro}, ${form.cidade} - ${form.estado}, ${form.cep}`
+        : "Retirada no local";
+
+    const produtos = cart
+      .map((i) => `${i.name} x${i.qty}${i.obs ? " (" + i.obs + ")" : ""}`)
+      .join(", ");
+
+    const quantidade = cart.reduce((t, i) => t + i.qty, 0);
+    const totalItens = cart.reduce((t, i) => t + i.price * i.qty, 0);
+    const frete = Number(form.frete || 0);
+
+    const pedido = {
+      id,
+      data,
+      nome: form.nome,
+      telefone: form.telefone,
+      endereco,
+      produtos,
+      frete,
+      quantidade,
+      total: Number((totalItens + frete).toFixed(2)),
+      pagamento:
+        form.pagamento === "dinheiro" && form.troco
+          ? `Dinheiro (troco para ${form.troco})`
+          : form.pagamento,
+      status: "Pendente",
+      observacoes: form.observacoes,
+    };
+
+    alert("Pedido enviado com sucesso!");
+    setCart([]);
+    setShowForm(false);
+
+    fetch("/api/enviar-pedido", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(pedido),
+    }).catch((err) => {
+      console.error("Falha ao enviar pedido:", err);
+    });
   };
 
   const total = cart.reduce((t, i) => t + i.price * i.qty, 0);


### PR DESCRIPTION
## Summary
- enviar pedidos para novo webhook
- exibir popup de sucesso imediatamente

## Testing
- `npm test --silent --prefix .`

------
https://chatgpt.com/codex/tasks/task_e_6874efab481c8327ab40434ceb9c992c