### PR TITLE
Hide menu when unavailable

### DIFF
--- a/src/pages/Landing.js
+++ b/src/pages/Landing.js
@@ -3,6 +3,7 @@ import { ShoppingCart, Plus, Minus, Trash, X } from "lucide-react";
 import { ToastContainer, toast } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 import AvailabilityNotice from "../components/AvailabilityNotice";
+import { checkAvailability } from "../utils/schedule";
 
 const freteOptions = [
   { label: "Pinhal – R$ 10,00", value: 10 },
@@ -28,6 +29,7 @@ export default function Landing() {
 
   const [active, setActive] = useState("lanche");
   const activeCategory = active === "marmita" ? "marmitas" : active === "lanche" ? "lanches" : null;
+  const categoryAvailable = activeCategory ? checkAvailability(activeCategory) : true;
   const [menu, setMenu] = useState({
     lanche: [],
     marmita: [],
@@ -293,7 +295,8 @@ export default function Landing() {
 
       <main className="max-w-4xl mx-auto p-4 space-y-4 pt-2">
         <AvailabilityNotice category={activeCategory} />
-        {menu[active].map((item) => (
+        {categoryAvailable &&
+          menu[active].map((item) => (
           <div
             key={item.id}
             className="bg-white rounded-lg shadow overflow-hidden"


### PR DESCRIPTION
## Summary
- prevent showing marmita and lanche menus outside their hours

## Testing
- `npm test --silent`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68782626953c8327829e97241c387407