### PR TITLE
Implement horizontal scrolling for menu items

### DIFF
--- a/src/pages/Landing.js
+++ b/src/pages/Landing.js
@@ -378,38 +378,41 @@ export default function Landing() {
         ))}
       </div>
 
-      <main className="max-w-4xl mx-auto p-4 space-y-4 pt-2">
+      <main className="max-w-4xl mx-auto p-4 pt-2">
         <AvailabilityNotice category={activeCategory} />
-        {categoryAvailable &&
-          menu[active].map((item) => (
-            <div
-              key={item.id}
-              className="bg-white rounded-lg shadow overflow-hidden"
-            >
-              <img
-                src={item.image}
-                alt={item.name}
-                className="h-40 w-full object-cover"
-              />
-              <div className="p-4">
-                <h3 className="font-playfair text-lg">{item.name}</h3>
-                {item.description && (
-                  <p className="text-sm text-gray-600 mb-2">
-                    {item.description}
-                  </p>
-                )}
-                <div className="flex justify-between items-center">
-                  <span className="font-bold">R$ {item.price.toFixed(2)}</span>
-                  <button
-                    onClick={() => addToCart(item)}
-                    className="bg-[#FFD700] text-black px-3 py-1 rounded-full shadow"
-                  >
-                    Adicionar
-                  </button>
+        {categoryAvailable && (
+          <div className="flex overflow-x-auto no-scrollbar space-x-4">
+            {menu[active].map((item) => (
+              <div
+                key={item.id}
+                className="flex-shrink-0 w-72 bg-white rounded-lg shadow overflow-hidden snap-start"
+              >
+                <img
+                  src={item.image}
+                  alt={item.name}
+                  className="h-40 w-full object-cover"
+                />
+                <div className="p-4">
+                  <h3 className="font-playfair text-lg">{item.name}</h3>
+                  {item.description && (
+                    <p className="text-sm text-gray-600 mb-2">
+                      {item.description}
+                    </p>
+                  )}
+                  <div className="flex justify-between items-center">
+                    <span className="font-bold">R$ {item.price.toFixed(2)}</span>
+                    <button
+                      onClick={() => addToCart(item)}
+                      className="bg-[#FFD700] text-black px-3 py-1 rounded-full shadow"
+                    >
+                      Adicionar
+                    </button>
+                  </div>
                 </div>
               </div>
-            </div>
-          ))}
+            ))}
+          </div>
+        )}
       </main>
 
       <ToastContainer position="bottom-right" style={{ bottom: "5rem" }} />


### PR DESCRIPTION
## Summary
- show menu items in a horizontally scrollable list so users can drag sideways

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_687c3ab1ea5c8327a9a35dfd41dc7bb5