### PR TITLE
Handle webhook error fallback to WhatsApp

### DIFF
--- a/api/webhook.js
+++ b/api/webhook.js
@@ -13,13 +13,39 @@ export default async function handler(req, res) {
     });
 
     const text = await response.text();
+    let data;
+
+    try {
+      data = text ? JSON.parse(text) : null;
+    } catch (parseError) {
+      data = null;
+    }
 
     if (!response.ok) {
       console.error("Erro ao enviar para webhook:", text);
-      return res.status(500).json({ error: "Erro ao encaminhar webhook", details: text });
+      return res
+        .status(response.status || 500)
+        .json({ error: "Erro ao encaminhar webhook", details: text || response.statusText });
     }
 
-    res.status(200).json({ message: "Webhook encaminhado com sucesso" });
+    if (
+      data &&
+      data.code === 0 &&
+      typeof data.message === "string" &&
+      data.message.toLowerCase().includes("no item to return got found")
+    ) {
+      console.error("Webhook retornou erro conhecido:", data);
+      return res.status(502).json({
+        error: "Erro ao encaminhar webhook",
+        details: data.message,
+        originalResponse: data,
+      });
+    }
+
+    res.status(200).json({
+      message: "Webhook encaminhado com sucesso",
+      payload: data ?? text ?? null,
+    });
   } catch (error) {
     console.error("Erro interno ao encaminhar webhook:", error);
     res.status(500).json({ error: "Erro interno ao encaminhar webhook", details: error.message });

--- a/src/pages/Landing.js
+++ b/src/pages/Landing.js
@@ -224,21 +224,10 @@ export default function Landing() {
       `\n\n*Pagamento:* ${pagamentoMsg}\n` +
       (observacoes ? `\n*Observações Gerais:*\n${observacoes}\n` : "") +
       `\n*Total:* R$ ${total.toFixed(2)}${promoText}\n`;
-
-    // Mensagem usada para notificação interna e fallback via WhatsApp.
-
-    fetch("/api/webhook", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ message: msg, order }),
-    }).catch((err) => {
-      console.error("Falha ao enviar webhook:", err);
-    });
-
     return msg;
   };
 
-  const handleSubmit = (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault();
 
     if (form.recebimento === "entrega" && !form.frete) {
@@ -324,6 +313,51 @@ export default function Landing() {
       order: pedido,
     });
 
+    const whatsappUrl = `https://wa.me/5511998110650?text=${encodeURIComponent(
+      whatsappMessage
+    )}`;
+
+    const fallbackToWhatsapp = (err) => {
+      console.error("Falha ao enviar webhook:", err);
+      toast.error(
+        "Erro ao enviar pedido. Envie-o diretamente para o WhatsApp do restaurante."
+      );
+      window.open(whatsappUrl, "_blank");
+    };
+
+    try {
+      const webhookResponse = await fetch("/api/webhook", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ message: whatsappMessage, order: pedido }),
+      });
+
+      const webhookText = await webhookResponse.text();
+
+      if (!webhookResponse.ok) {
+        throw new Error(webhookText || "Erro ao encaminhar webhook");
+      }
+
+      if (webhookText) {
+        try {
+          const webhookData = JSON.parse(webhookText);
+          if (
+            webhookData &&
+            webhookData.code === 0 &&
+            typeof webhookData.message === "string" &&
+            webhookData.message.toLowerCase().includes("no item to return got found")
+          ) {
+            throw new Error(webhookData.message);
+          }
+        } catch (parseError) {
+          // Resposta não é um JSON válido; seguir normalmente.
+        }
+      }
+    } catch (err) {
+      fallbackToWhatsapp(err);
+      return;
+    }
+
     toast.success("Recebemos o seu pedido! Muito obrigado.");
     setCart([]);
     setShowForm(false);
@@ -344,9 +378,6 @@ export default function Landing() {
         toast.error(
           "Erro ao enviar pedido. Envie-o diretamente para o WhatsApp do restaurante."
         );
-        const whatsappUrl = `https://wa.me/5511998110650?text=${encodeURIComponent(
-          whatsappMessage
-        )}`;
         window.open(whatsappUrl, "_blank");
       });
   };

--- a/src/pages/Landing.js
+++ b/src/pages/Landing.js
@@ -317,12 +317,19 @@ export default function Landing() {
       whatsappMessage
     )}`;
 
+    const redirectToWhatsapp = () => {
+      const newWindow = window.open(whatsappUrl, "_blank");
+      if (!newWindow || newWindow.closed) {
+        window.location.href = whatsappUrl;
+      }
+    };
+
     const fallbackToWhatsapp = (err) => {
-      console.error("Falha ao enviar webhook:", err);
+      console.error("Falha ao processar pedido:", err);
       toast.error(
         "Erro ao enviar pedido. Envie-o diretamente para o WhatsApp do restaurante."
       );
-      window.open(whatsappUrl, "_blank");
+      redirectToWhatsapp();
     };
 
     try {
@@ -378,7 +385,7 @@ export default function Landing() {
         toast.error(
           "Erro ao enviar pedido. Envie-o diretamente para o WhatsApp do restaurante."
         );
-        window.open(whatsappUrl, "_blank");
+        redirectToWhatsapp();
       });
   };
 


### PR DESCRIPTION
## Summary
- parse the webhook response on the API route and treat the known `code: 0` payload as an error
- update the order submission flow to await the webhook call and fall back to WhatsApp when it fails

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6907e525bc548327bdca0709a4e56e94